### PR TITLE
Add open-on-load example

### DIFF
--- a/examples-common-usage/index.html
+++ b/examples-common-usage/index.html
@@ -16,6 +16,7 @@
     <a href="/custom-button.html">Custom button</a>
     <a href="/custom-buttons.html">Custom buttons</a>
     <a href="/full-hydration.html">Full hydration</a>
+    <a href="/open-on-load.html">Open on load</a>
     <a href="/partial-hydration.html">Partial hydration</a>
   </body>
 </html>

--- a/examples-common-usage/open-on-load.html
+++ b/examples-common-usage/open-on-load.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <title>Open on load example | Peddle Publisher Embed</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1"/>
+    <script>
+      PeddlePublisherEmbedConfig={publisherID:"118535"},
+      function(){if("function"!=typeof window.PeddlePublisherEmbed){if(!window.PeddlePublisherEmbedConfig||!window.PeddlePublisherEmbedConfig.publisherID)throw new Error("Unable to bootstrap Peddle Publisher Embed, make sure to set PeddlePublisherEmbedConfig.publisherID");const e=(d,i)=>{e.queue.push({operation:d,options:i})};e.queue=[],window.PeddlePublisherEmbed=e;const d=()=>{const e=document.createElement("script");e.type="text/javascript",e.async=!0,e.src="https://publisher-embed.peddle.com/api/v1/embed/"+window.PeddlePublisherEmbedConfig.publisherID;const d=document.getElementsByTagName("script")[0];d.parentNode.insertBefore(e,d)};window.addEventListener("load",d,!1)}}();
+    </script>
+    <script>
+      // call PeddlePublisherEmbed('open') to open the embed on window load
+      window.addEventListener('load', function() {
+        PeddlePublisherEmbed('open');
+      });
+    </script>
+  </head>
+  <body>
+    <div id="peddle-button" />
+  </body>
+</html>


### PR DESCRIPTION
Some publishers would like to open the Publisher Embed on load of the page.

This extends the common examples to provide some insight into how to achieve that functionality

—

To test, load the Render page in your browser:
https://peddle-publisher-examples-common-usage-4gcs.onrender.com/open-on-load.html

The embed should immediately appear on page load